### PR TITLE
Add video & slides URLs for Luis' talk as sample data

### DIFF
--- a/data/talks/2017/11/pipelines-in-the-wild.json
+++ b/data/talks/2017/11/pipelines-in-the-wild.json
@@ -4,5 +4,7 @@
   "event" : "the-final-pipeline",
   "speakers" : [
     "luis-ferro"
-  ]
+  ],
+  "video-url" : "https://www.youtube.com/watch?v=xCXHUJ5jECk",
+  "slides-url" : "https://github.com/lferro9000/jenkins-pipelines-slides/releases/tag/v1.0.3"
 }


### PR DESCRIPTION
Thought I would get this in for some real sample data.
The slides link is one of those where we'll need to just link, rather than embed (which hopefully we can do for PDFs & Slideshare).