### PR TITLE
Remove meanbee & Equiniti

### DIFF
--- a/data/website/website.json
+++ b/data/website/website.json
@@ -7,8 +7,6 @@
       "deep-blue-sky",
       "edo",
       "ents24",
-      "equiniti",
-      "meanbee",
       "space-48"
   ],
   "organisers" : [


### PR DESCRIPTION
Meanbee have been accidentally added back in (they are now Space48)
Equiniti no longer sponsor