### PR TITLE
Don't set the user agent if not available.

### DIFF
--- a/app/src/DataFileGenerator/MeetupApiClient.php
+++ b/app/src/DataFileGenerator/MeetupApiClient.php
@@ -177,7 +177,9 @@ class MeetupApiClient
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 120);
         curl_setopt($ch, CURLOPT_TIMEOUT, 120);
         curl_setopt($ch, CURLOPT_HEADER, false);
-        curl_setopt($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+        if (!empty($_SERVER['HTTP_USER_AGENT'])) {
+            curl_setopt($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+        }
 
         //either GET/POST/PUT/DELETE against api
         if (self::GET == $action || self::DELETE == $action) {


### PR DESCRIPTION
The user agent isn't set in $_SERVER when the client is used from the command line, d'oh :) So make it optional.