### PR TITLE
Fix talk width

### DIFF
--- a/app/resources/views/partials/talks/talk.html.twig
+++ b/app/resources/views/partials/talks/talk.html.twig
@@ -1,5 +1,5 @@
 <div class="mb-8 flex flex-row-reverse">
-    <div>
+    <div class="flex-1">
         <h2 class="mb-1">
             <a href="{{ talkUrl(talk) }}">
                 {{ talk.title }}


### PR DESCRIPTION
Fix issue with widths for talks that have no content.

<img width="1280" alt="screen shot 2018-07-19 at 19 43 20" src="https://user-images.githubusercontent.com/339813/42963419-19e99b1e-8b8c-11e8-84b8-1ba1e3a1b107.png">
